### PR TITLE
fix: missing deps resolve error output

### DIFF
--- a/internal/cmd/cmd_deps.go
+++ b/internal/cmd/cmd_deps.go
@@ -37,7 +37,7 @@ func depsCommand(
 	if opts.resolve {
 		ings, rerr := res.Resolve(ctx, deps)
 		if rerr != nil {
-			return err
+			return rerr
 		}
 
 		result = ings


### PR DESCRIPTION
there were no error message on dependency resolvation error at k6x deps --resolve