### PR TITLE
fix: cursor disappeared in terminal after interrupt

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"text/template"
 
@@ -45,6 +46,15 @@ func main(
 	}
 
 	initLogger(opts)
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for range c {
+			opts.spinner.Stop()
+			os.Exit(1)
+		}
+	}()
 
 	res := resolver.NewWithCacheDir(opts.dirs.http)
 	cmd := filepath.Join(opts.dirs.bin, k6Binary)


### PR DESCRIPTION
Cursor disappeared on linux when I pressed CTRL + C while spinner was active