### PR TITLE
Feature/containerize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023 Iván SZKIBA
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: 'amd64,arm64'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}          
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 project_name: k6x
+env:
+  - OWNER=szkiba
 before:
   hooks:
     - go mod tidy
@@ -12,7 +14,7 @@ builds:
     goos:  [ 'darwin', 'linux', 'windows' ]
     goarch: [ 'amd64', 'arm64' ]
     ldflags:
-      - '-s -w -X {{.ModulePath}}/internal/cmd._version={{.Version}} -X {{.ModulePath}}/internal/cmd._appname={{.ProjectName}}'
+      - '-s -w -X {{.ModulePath}}/internal/cmd._version={{.Version}} -X {{.ModulePath}}/internal/cmd._appname={{.ProjectName}} -X {{.ModulePath}}/internal/cmd._owner={{index .Env "GITHUB_REPOSITORY_OWNER"}}'
 source:
   enabled: true
   name_template: '{{ .ProjectName }}_{{ .Version }}_source'
@@ -30,7 +32,7 @@ nfpms:
     description: |-
       Automatic k6 provisioning with extensions.
 
-    license: MIT
+    license: AGPL-3.0-only
     formats: [ 'deb', 'rpm' ]
     umask: 0o022
     overrides:
@@ -61,3 +63,61 @@ changelog:
       - '^chore:'
       - '^docs:'
       - '^test:'
+
+dockers:
+  - id: amd64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:latest-amd64"
+
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0-only"
+  - id: arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "{{ .Env.OWNER }}/{{ .ProjectName }}:latest-amd64"
+
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0-only"
+
+docker_manifests:
+- id: tag
+  name_template: "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}"
+  image_templates:
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64"
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}-arm64"
+- id: major
+  name_template: "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}"
+  image_templates:
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}-amd64"
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}-arm64"
+- id: major-minor
+  name_template: "{{ .Env.OWNER }}/{{ .ProjectName }}:{{ .Tag }}"
+  image_templates:
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-amd64"
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-arm64"
+- id: latest
+  name_template: "{{ .Env.OWNER }}/{{ .ProjectName }}:latest"
+  image_templates:
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:latest"
+  - "{{ .Env.OWNER }}/{{ .ProjectName }}:latest"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 Iván SZKIBA
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+FROM golang:1.21.1-alpine3.18
+VOLUME /cache
+RUN apk add --no-cache ca-certificates git && \
+    adduser -D -u 10000 -g 10000 -h /home/k6x k6x && \
+    mkdir -p /cache/go-build /cache/go-mod /cache/k6x && \
+    chown -R 10000:10000 /cache
+ENV XDG_CACHE_HOME="/cache" GOCACHE="/cache/go-build" GOMODCACHE="/cache/go-mod"
+COPY k6x /usr/bin/k6x
+
+USER 10000
+WORKDIR /home/k6x
+ENTRYPOINT ["k6x"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ If you have a go development environment, the installation can also be done with
 go install github.com/szkiba/k6x@latest
 ```
 
+## Docker
+
+k6x is also available as a docker image on Docker Hub under the name [szkiba/k6x](https://hub.docker.com/r/szkiba/k6x).
+
+This docker image can be used as a replacement for the official k6 docker image to run test scripts that use extensions. The basic use of the image is the same as using the official k6 image.
+
+The image automatically provides  [k6](https://k6.io) with the [extensions](https://k6.io/docs/extensions/) used by the tests. To do this, [k6x](https://github.com/szkiba/k6x) analyzes the test script and creates a list of required extensions (it also parses the command line to detect output extensions). Based on this list, k6x builds (and caches) the k6 binary and runs it.
+
+The build step is done using the go compiler included in the image. The partial results of the go compilation and build steps are saved to the volume in the `/cache` path (this is where the go cache and the go module cache are placed). By making this volume persistent, the time required for the build step can be significantly reduced.
+
+The k6x docker builder (`--builder docker`) also uses this docker image. It creates a local volume called `k6x-cache` and mounts it to the `/cache` path. Thanks to this, the docker build runs almost at the same speed as the native build (apart from the first build).
+
 ## Extras
 
 ### Pragma
@@ -170,7 +182,7 @@ The compiled k6 binary is stored in the cache. This binary will be used as long 
 
 At this point, the k6 binary is executed from the cache with exactly the same arguments that were used to start the k6x command.
 
-You can read more about the development ideas in the [Future](#future) section.
+You can read more about the development ideas in the [Feature Request](https://github.com/szkiba/k6x/issues?q=is%3Aopen+is%3Aissue+label%3Afeature) list.
 
 ### Limitations
 
@@ -247,6 +259,3 @@ major change is API breaking. For example,
 * `^0.0` is equivalent to `>=0.0.0 <0.1.0`
 * `^0` is equivalent to `>=0.0.0 <1.0.0`
 
-## Future
-
-One possible future development idea is to make it possible to use pre-built k6 binaries. Instead of building, the k6 binary could be downloaded from properly prepared custom k6 GitHub releases. This will allow you to use k6x even without Docker Engine. In addition, the use of pre-built k6 binaries will significantly reduce the cache loading time (from 45-50 seconds to a few seconds).

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ Read the version constraints syntax in the [Version Constraints](#version-constr
 
 Reusable artifacts (k6 binary, HTTP responses) are stored in the subdirectory `k6x` under the directory defined by the `XDG_CACHE_HOME` environment variable. The default of `XDG_CACHE_HOME` depends on the operating system (Windows: `%LOCALAPPDATA%\cache`, Linux: `~/.cache`, macOS: `~/Library/Caches`)
 
-The directory where k6x stores the compiled k6 binary can be specified in the `K6X_BIN_DIR` environment variable. If it is missing, the `.k6x` directory is used if it exists in the current working directory, otherwise the k6 binary is stored in the cache directory described above. In addition, the location of the directory used to store k6 can also be specified using the `--bin-dir` command line option. See the [Options](#options) section for more information.
+The directory where k6x stores the compiled k6 binary can be specified in the `K6X_BIN_DIR` environment variable. If it is missing, the `.k6x` directory is used if it exists in the current working directory, otherwise the k6 binary is stored in the cache directory described above. In addition, the location of the directory used to store k6 can also be specified using the `--bin-dir` command line option. See the [Flags](#flags) section for more information.
 
 The `version` command displays the path of the cached k6 executable after the version number.
 
 > **Note**
 > You can avoid rebuilding the k6 binary in the default k6x cache during development if you create a .k6x directory in the current working directory. In this case, k6x will automatically use this local directory to cache the k6 binary.
 
-### Options
+### Flags
 
-The k6 subcommands are extended with some global command line options related to building and caching the k6 binary.
+The k6 subcommands are extended with some global command line flags related to building and caching the k6 binary.
 
 - `--clean` the cached k6 binary will be deleted and a new binary will be built
 - `--dry` only the cached k6 binary will be updated if necessary, the k6 command will not be executed
@@ -97,7 +97,12 @@ The k6 subcommands are extended with some global command line options related to
   ```
   k6x run --bin-dir ./custom-k6 script.js
   ```
+- `--with dependency`  you can specify additional dependencies and version constraints, the form of the `dependency` is the same as that used in the `"use k6 with"` pragma (practically the same as the string after the `use k6 with`)
 
+  ```
+  k6x run --with k6/x/mock script.js
+  ```
+  
 - `--builder list` a comma-separated list of builders (default: `native,docker`), available builders:
   - `native` this builder uses the installed go compiler if available, otherwise the next builder is used without error
   - `docker` this builder uses Docker Engine, which can be local or remote (specified in `DOCKER_HOST` environment variable)
@@ -113,7 +118,7 @@ Some new subcommands will also appear, which are related to building the k6 bina
 - `build` builds k6 based on the dependencies in the test script.
   ```
   Usage:
-    k6x build [flags] script
+    k6x build [flags] [script]
 
   Flags:
     -o, --out name  output extension name
@@ -125,7 +130,7 @@ Some new subcommands will also appear, which are related to building the k6 bina
 - `deps` display of k6 and extension dependencies used in the test script
   ```
   Usage:
-    k6x deps [flags] script
+    k6x deps [flags] [script]
 
   Flags:
     -o, --out name  output extension name
@@ -138,7 +143,7 @@ Some new subcommands will also appear, which are related to building the k6 bina
 
 The new subcommands (`build`, `deps`) display help in the usual way, with the `--help` or `-h` command line option.
 
-The k6 subcommands (`version`, `run` etc) also display help with the `--help` or `-h` command line option, so in this case the new k6x launcher options are displayed before the normal k6 help.
+The k6 subcommands (`version`, `run` etc) also display help with the `--help` or `-h` command line option, so in this case the new k6x launcher flags are displayed before the normal k6 help.
 
 ### Remote Docker
 
@@ -159,7 +164,7 @@ The git repository for each extension is determined based on the [k6 extension r
 
 Taking into account the optional version constraints, the appropriate extension version is selected from the git tags of the extension's git repository. Currently, only GitHub repositories are supported, if required, additional repository managers can be supported (eg GitLab).
 
-If the Go compiler is installed, the k6 binary is created using it. Otherwise the custom k6 binary is created using the [xk6 custom k6 builder docker image](https://hub.docker.com/r/grafana/xk6/). The Docker Engine API is accessed using the [docker go client](https://pkg.go.dev/github.com/docker/docker/client), so there is no need for a docker cli command and even a remote Docker Engine can be used.
+If the Go compiler is installed, the k6 binary is created using it. Otherwise the custom k6 binary is created using the [szkiba/k6x](https://hub.docker.com/r/szkiba/k6x) docker image. The Docker Engine API is accessed using the [docker go client](https://pkg.go.dev/github.com/docker/docker/client), so there is no need for a docker cli command and even a remote Docker Engine can be used.
 
 The compiled k6 binary is stored in the cache. This binary will be used as long as the extensions included in it meet the current requirements, taking into account the optional version constraints. In order to increase the efficiency of the cache, the newly built k6 binary will also include the previously used extensions (if they are still included in the registry).
 

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -71,6 +71,23 @@ func addOptional(ctx context.Context, res resolver.Resolver, deps, opt dependenc
 	}
 }
 
+func addDeps(ctx context.Context, res resolver.Resolver, deps, req dependency.Dependencies) error {
+	if len(req) == 0 {
+		return nil
+	}
+
+	_, err := res.Resolve(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	for name, dep := range req {
+		deps[name] = dep
+	}
+
+	return nil
+}
+
 func collectDependencies(
 	ctx context.Context,
 	res resolver.Resolver,
@@ -101,6 +118,14 @@ func collectDependencies(
 	}
 
 	addOptional(ctx, res, deps, opts.dependencies())
+
+	if err := addDeps(ctx, res, deps, opts.with); err != nil {
+		return nil, err
+	}
+
+	if _, has := deps.K6(); !has {
+		deps["k6"] = &dependency.Dependency{Name: "k6"}
+	}
 
 	return deps, nil
 }

--- a/internal/cmd/cmd_build.go
+++ b/internal/cmd/cmd_build.go
@@ -35,12 +35,13 @@ func buildCommand(
 const buildUsage = `Build custom k6 binary for a script.
 
 Usage:
-  {{.appname}} build [flags] script
+  {{.appname}} build [flags] [script]
 
 Flags:
-  -o, --out name  output extension name
-  --bin-dir path  folder for custom k6 binary (default: {{.bin}})
-  --builder list  comma separated list of builders (default: native,docker)
-  --no-color      disable colored output  
-  -h, --help      display this help
+  -o, --out name     output extension name
+  --bin-dir path     folder for custom k6 binary (default: {{.bin}})
+  --with dependency  additional dependency and version constraints
+  --builder list     comma separated list of builders (default: native,docker)
+  --no-color         disable colored output  
+  -h, --help         display this help
 `

--- a/internal/cmd/cmd_deps.go
+++ b/internal/cmd/cmd_deps.go
@@ -63,11 +63,13 @@ func depsCommand(
 const depsUsage = `Print k6 and extension dependencies for a script.
 
 Usage:
-  {{.appname}} deps [flags] script
+  {{.appname}} deps [flags] [script]
 
 Flags:
-  -o, --out name  output extension name
-  --json          use JSON output format
-  --resolve       print resolved dependencies
+  -o, --out name     output extension name
+  --json             use JSON output format
+  --resolve          print resolved dependencies
+  --with dependency  additional dependency and version constraints
+
   -h, --help      display this help
 `

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -140,9 +140,10 @@ Launcher Commands:
   build  Build custom k6 binary with extensions
 
 Launcher Flags:
-  --bin-dir path  cache folder for k6 binary (default: {{.bin}})
-  --builder list  comma separated list of builders (default: native,docker)
-  --clean         remove cached k6 binary
-  --dry           do not run k6 command
+  --bin-dir path     cache folder for k6 binary (default: {{.bin}})
+  --with dependency  additional dependency and version constraints
+  --builder list     comma separated list of builders (default: native,docker)
+  --clean            remove cached k6 binary
+  --dry              do not run k6 command
 `
 )

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -249,7 +249,7 @@ func test() error {
 
 func build() error {
 	_, err := sh.Exec(
-		nil,
+		map[string]string{"CGO_ENABLED": "0"},
 		os.Stdout,
 		os.Stderr,
 		"go",

--- a/releases/v0.3.0.md
+++ b/releases/v0.3.0.md
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: 2023 Iván SZKIBA
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+k6x `v0.3.0` is here 🎉!
+
+Main new features:
+
+ - [Docker Image](#docker-image) [#6](https://github.com/szkiba/k6x/issues/6)
+ - [Add dependencies on the command line](#add-dependencies-on-the-command-line) ([#10](https://github.com/szkiba/k6x/issues/10))
+
+## Add dependencies on the command line
+
+In some cases, it may be useful to add dependencies on the command line without modifying the test script.
+
+Additional dependencies and version constraints can be specified on the command line with the --with flag.
+
+`--with dependency`  you can specify additional dependencies and version constraints, the form of the `dependency` is the same as that used in the `"use k6 with"` pragma (practically the same as the string after the `use k6 with`)
+
+```
+k6x run --with k6/x/mock script.js
+```
+
+*The example above adds the xk6-mock extension to the list of dependencies.*
+
+## Docker Image
+
+In certain circumstances, it can be useful to run k6x using the docker engine itself, as a drop-in replacement of the k6 docker image. Therefore, it is advisable to publish in the form of a docker image that contains the tools necessary for building (golang, git).
+
+The [szkiba/k6x](https://hub.docker.com/r/szkiba/k6x) docker image is available from the Docker Hub.
+
+The k6x docker builder (`--builder docker`) now uses the k6x docker image instead of the xk6 docker image to build the k6 binary. This results in a significant reduction in build time. The speed increase is due to the use of persistent go cache. The `k6x-cache` volume is a persistent local docker volume. This is where the go cache and the go module cache are placed.
+


### PR DESCRIPTION
Main new features:

 - [Docker Image](#docker-image) [#6](https://github.com/szkiba/k6x/issues/6)
 - [Add dependencies on the command line](#add-dependencies-on-the-command-line) ([#10](https://github.com/szkiba/k6x/issues/10))

## Add dependencies on the command line

In some cases, it may be useful to add dependencies on the command line without modifying the test script.

Additional dependencies and version constraints can be specified on the command line with the --with flag.

`--with dependency`  you can specify additional dependencies and version constraints, the form of the `dependency` is the same as that used in the `"use k6 with"` pragma (practically the same as the string after the `use k6 with`)

```
k6x run --with k6/x/mock script.js
```

*The example above adds the xk6-mock extension to the list of dependencies.*

## Docker Image

In certain circumstances, it can be useful to run k6x using the docker engine itself, as a drop-in replacement of the k6 docker image. Therefore, it is advisable to publish in the form of a docker image that contains the tools necessary for building (golang, git).

The [szkiba/k6x](https://hub.docker.com/r/szkiba/k6x) docker image is available from the Docker Hub.

The k6x docker builder (`--builder docker`) now uses the k6x docker image instead of the xk6 docker image to build the k6 binary. This results in a significant reduction in build time. The speed increase is due to the use of persistent go cache. The `k6x-cache` volume is a persistent local docker volume. This is where the go cache and the go module cache are placed.

